### PR TITLE
Move to CVC5 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvc5==1.2.0
+cvc5==1.3.0
 coverage
 pylint
 pycodestyle


### PR DESCRIPTION
I'm needing PyVCG for a Python3.13 project, which is supported only in CVC5 1.3.0.
This means I'll need a new release of this project as well, so I can set the PyPI dependency accordingly.

- ✔️ Tests ran locally and pass