### PR TITLE
Capture also Return value str.++

### DIFF
--- a/pyvcg/driver/cvc5_smtlib.py
+++ b/pyvcg/driver/cvc5_smtlib.py
@@ -317,7 +317,7 @@ class CVC5_Result_Parser:
         assert isinstance(etyp, smt.Sort)
         self.match("BRA")
         self.match("IDENTIFIER")
-        if self.ct.value == "seq.++":
+        if self.ct.value in ("seq.++", "str.++"):
             rv = []
             while self.nt and not self.peek("KET"):
                 rv += self.parse_seq(etyp)


### PR DESCRIPTION
in some situations cvc5 also returns a str.++ instead of a seq.++

For instance if Functional Tests in TRLC are enabled for Quantifier Field Acces and executing test case tests-system/field-access-1/