### PR TITLE
Move to CVC 1.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvc5==1.3.2
+cvc5==1.3.4
 coverage
 pylint
 pycodestyle

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="GNU General Public License v3",
     packages=["pyvcg", "pyvcg.driver"],
     extras_require={
-        "api": ["cvc5==1.3.2"],
+        "api": ["cvc5==1.3.4"],
     },
     python_requires=">=3.8",
     classifiers=[


### PR DESCRIPTION
Needed for Python 3.14 support.

Also, I've been wondering: is pining cvc5 version really necessary here? Do we experience any specific API incompatibility? In my mind the package intaller (pip) will already choose the compatible version.

Resolves https://github.com/florianschanda/PyVCG/issues/8.